### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,13 @@ if  (NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(json)
 endif()
 
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Wpedantic -Werror")
+# Check if the project is being added as a submodule
+if (NOT ${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+  #inherit the cmake cxx flags from the parent project
+  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ")
+else()
+  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Wpedantic -Werror")
+endif()
 
 add_subdirectory(src)
 enable_testing()


### PR DESCRIPTION
Under new pawesey env AMD has added something that the compiler deems illegal 

```
In file included from /opt/rocm/include/hip/amd_detail/amd_channel_descriptor.h:28,
                 from /opt/rocm/include/hip/channel_descriptor.h:32,
                 from /opt/rocm/include/hip/texture_types.h:38,
                 from /opt/rocm/include/hip/hip_runtime_api.h:505,
                 from /opt/rocm/include/hip/hip_runtime.h:113,
                 from /software/projects/director2178/jorgeg94/HERMES/external/rtatblas/src/gpu-api/gpu-api.h:6,
                 from /software/projects/director2178/jorgeg94/HERMES/external/rtatblas/src/gpu-api/gpu-api.cpp:1:
/opt/rocm/include/hip/amd_detail/amd_hip_vector_types.h:645:20: warning: ISO C++ prohibits anonymous structs [-Wpedantic]
  645 |             struct {
```

Removing Werror works, but removing Werror needs to be propagated from exess down to rtat. This fix will make it so that rtat inherits flags form exess if built as submodule, but will add the ones that were default if not. 